### PR TITLE
test: add tests for animation addition and deletion in Animation controller

### DIFF
--- a/tests/routes/animationController.test.js
+++ b/tests/routes/animationController.test.js
@@ -1,0 +1,107 @@
+const mongoose = require("mongoose");
+const {
+  addObjectAnimation,
+  deleteObjectAnimation,
+} = require("../../controllers/animationController");
+
+jest.mock("../../models/Presentation");
+const Presentation = require("../../models/Presentation");
+
+describe("AnimationController", () => {
+  const mockPresentationId = new mongoose.Types.ObjectId().toString();
+  const mockSlideId = new mongoose.Types.ObjectId().toString();
+  const mockObjectId = new mongoose.Types.ObjectId().toString();
+  const mockAnimationType = "mockAnimationType";
+
+  describe("POST /user/:userId/presentation/:presentationId/slide/:slideId/object/:objectId", () => {
+    it("should add an animation when presentation, slide, and object exist", async () => {
+      const mockSlide = {
+        objects: {
+          id: jest.fn().mockReturnValueOnce({
+            _id: mockObjectId,
+            currentAnimation: null,
+          }),
+        },
+        animationSequence: [],
+      };
+
+      const mockPresentation = {
+        slides: {
+          id: jest.fn().mockReturnValueOnce(mockSlide),
+        },
+        save: jest.fn(),
+      };
+
+      Presentation.findById.mockResolvedValueOnce(mockPresentation);
+
+      const reqMock = {
+        params: {
+          presentation_id: mockPresentationId,
+          slide_id: mockSlideId,
+          object_id: mockObjectId,
+        },
+        body: { animationType: mockAnimationType },
+      };
+
+      const resMock = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await addObjectAnimation(reqMock, resMock, () => {});
+
+      expect(resMock.json).toHaveBeenCalledWith({
+        result: "success",
+        message: "Animation successfully added",
+        animationSequence: expect.any(Array),
+      });
+    });
+  });
+
+  describe("DELETE /user/:userId/presentation/:presentationId/slide/:slideId/object/:objectId/animation", () => {
+    it("should delete the animation from the object and remove it from animation sequence", async () => {
+      const mockPresentation = {
+        slides: {
+          id: jest.fn().mockReturnValueOnce({
+            objects: {
+              id: jest.fn().mockReturnValueOnce({
+                _id: mockObjectId,
+                currentAnimation: mockAnimationType,
+              }),
+            },
+            animationSequence: [
+              {
+                objectId: mockObjectId,
+                animationEffect: mockAnimationType,
+              },
+            ],
+          }),
+        },
+        save: jest.fn(),
+      };
+
+      Presentation.findById.mockResolvedValueOnce(mockPresentation);
+
+      const reqMock = {
+        params: {
+          presentation_id: mockPresentationId,
+          slide_id: mockSlideId,
+          object_id: mockObjectId,
+        },
+      };
+
+      const resMock = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await deleteObjectAnimation(reqMock, resMock, () => {});
+
+      expect(resMock.json).toHaveBeenCalledWith({
+        result: "success",
+        message:
+          "Animation successfully deleted, and was removed from animation sequence",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 개요
Animation controller의 Add와 Delete의 테스트 케이스를 추가했습니다. 

## 작업사항
addObjectAnimation - 객체에 애니메이션을 추가하는 기능을 테스트합니다.
deleteObjectAnimation - 객체에서 애니메이션을 삭제하고, 해당 애니메이션을 애니메이션 시퀀스에서 제거하는 기능을 테스트합니다.
각 함수는 Presentation 모델의 findById 메서드를 mock하여 데이터베이스와의 상호작용을 시뮬레이션하고, 예상 결과를 JSON 형태로 응답하는지 검증하는 테스트 함수입니다. 
